### PR TITLE
Change classes artifact jar naming

### DIFF
--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
@@ -132,7 +132,7 @@ class CopyDependenciesTask extends DefaultTask {
                 if (archiveName == null || file.name == archiveName) {
                     println "Artifact: " + file.name
                     if (file.name.endsWith(".aar")) {
-                        processZipFile(file, dependency.name)
+                        processZipFile(file, dependency)
                     } else if (file.name.endsWith(".jar")) {
                         if (!file.name.contains("sources")) {
                             copyArtifactFrom(file.path)
@@ -146,8 +146,8 @@ class CopyDependenciesTask extends DefaultTask {
         println()
     }
 
-    def processZipFile(File aarFile, String dependencyName) {
-        String tempDirPath = "${temporaryDir.path}/${dependencyName}_zip"
+    def processZipFile(File aarFile, Dependency dependency) {
+        String tempDirPath = "${temporaryDir.path}/${dependency.name}_zip"
 
         project.copy {
             from project.zipTree(aarFile.path)
@@ -161,7 +161,7 @@ class CopyDependenciesTask extends DefaultTask {
             from "${tempFolder.path}"
             include "classes.jar"
             into "${temporaryDir.path}/${variantName}/libs"
-            rename "classes.jar", "${dependencyName.toLowerCase()}.jar"
+            rename "classes.jar", "${dependency.group.toLowerCase()}-${dependency.name.toLowerCase()}-${dependency.version}.jar"
         }
 
         project.copy {


### PR DESCRIPTION
Currently, the `classes.jar` file from a source AAR is renamed to `dependencyName` and put inside the libs folder when creating the final AAR dependency. However, as it uses only the name, it may clash with another `.jar` file dependency it has and thus losing its classes.

Example: If I have a project dependency called example (`project(:example)`) and inside this project I have another sub-dependency called `example.jar`, the classes of the main project file would be lost as the sub-dependency would overwrite the jar with the same name.

This PR changes the naming of the dependency artifact to user the format `group-name-version` so we avoid naming clashes.

Co-authored-by: Igor Borges <igor@borges.me>