### PR TITLE
small fixes

### DIFF
--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/DependencyProcessorPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/DependencyProcessorPlugin.groovy
@@ -23,7 +23,7 @@ class DependencyProcessorPlugin implements Plugin<Project> {
         this.extension = project.extensions.create("aarPlugin", PluginExtension)
 
         project.parent.buildscript.getConfigurations().getByName("classpath").getDependencies().each { Dependency dep ->
-            if (dep.name == "gradle") {
+            if (dep.group == "com.android.tools.build" && dep.name == "gradle") {
                 gradleVersion = dep.version
             }
         }

--- a/example-nested-native-lib/jni/Application.mk
+++ b/example-nested-native-lib/jni/Application.mk
@@ -1,5 +1,4 @@
-APP_STL := gnustl_static
+APP_STL := c++_static
 APP_CPPFLAGS := -frtti -fexceptions
 APP_ABI := armeabi armeabi-v7a arm64-v8a
 APP_PLATFORM := android-9
-NDK_TOOLCHAIN_VERSION=4.9


### PR DESCRIPTION
hey there,

thanks a lot for this plugin! it is the only option that worked for me to fix https://issuetracker.google.com/issues/62121508

unfortunately i lost half a day debugging your plugin because it was not copying all my classes properly. turns out it assumed the wrong gradle version because i had a classpath-dependency called "io.fabric.tools:gradle:1.26.1". ouch!

moreover, i fixed your sample project to work with latest NDK (16+)