### PR TITLE
This fixes #16 - Crash when renaming jar file.

### DIFF
--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
@@ -188,7 +188,8 @@ class CopyDependenciesTask extends DefaultTask {
             from "${tempFolder.path}"
             include "classes.jar"
             into "${temporaryDir.path}/${variantName}/libs"
-            rename "classes.jar", "${dependency.group.toLowerCase()}-${dependency.name.toLowerCase()}-${dependency.version}.jar"
+            def jarName = getJarNameFromDependency(dependency)
+            rename "classes.jar", jarName
         }
 
         project.copy {
@@ -220,6 +221,20 @@ class CopyDependenciesTask extends DefaultTask {
         processRsFile(tempFolder)
 
         tempFolder.deleteDir()
+    }
+
+    def getJarNameFromDependency(Dependency dependency) {
+        def jarName = ""
+        if (null != dependency.group) {
+            jarName += dependency.group.toLowerCase() + "-"
+        }
+        jarName += dependency.name.toLowerCase()
+        if(null != dependency.version && !dependency.version.equalsIgnoreCase('unspecified')) {
+            jarName += "-" + dependency.version
+        }
+        jarName += ".jar"
+
+        return jarName
     }
     
     def processRsAwareFile(File resAwareFile) {


### PR DESCRIPTION
Hello,

I performed the following:
- To avoid the crash, I added some null checks around the Dependency's @Nullable methods. 
- I moved the code that creates the jar file name based on the Dependency object to a separate method to keep the code readable.
- I performed a build on the sample project and validated that the fat aar is correctly generated.

Cheers,
Jon