### PR TITLE
Updated dependencies:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.10'
+        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.10.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
How do I verify this? I have a local issue, but I don't know if this is a problem in practice:

```
Could not get unknown property 'mavenReleaseUrl' for object of type org.gradle.api.publication.maven.internal.deployer.DefaultGroovyMavenDeployer.
```

- Android Gradle Plugin (3.1.4 -> 3.3.1)
- Plugin Publish Plugin (0.9.10 -> 0.10.1)