### PR TITLE
Exclude javadocs from deps

### DIFF
--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
@@ -423,7 +423,7 @@ class CopyDependenciesTask extends DefaultTask {
                             println "   /--> " + file.name
                             processPomFile(file.path)
                         } else {
-                            if (!file.name.contains("sources")) {
+                            if (!file.name.contains("sources") && !file.name.contains("javadoc")) {
                                 copyArtifactFrom(file.path)
                             }
                         }


### PR DESCRIPTION
Javadocs jar are being included in result aar, so I used the same logic used for "sources" jar to remove the "javadoc" jar