### PR TITLE
packagesToExclude and bundled aars from POMs

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,3 +1,3 @@
 GROUP=com.mobbeel.plugin
 ARTIFACT_ID=fataar
-VERSION_NAME=2.1.1
+VERSION_NAME=2.0.3

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,3 +1,3 @@
 GROUP=com.mobbeel.plugin
 ARTIFACT_ID=fataar
-VERSION_NAME=2.0.3
+VERSION_NAME=2.1.1

--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/DependencyProcessorPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/DependencyProcessorPlugin.groovy
@@ -58,6 +58,7 @@ class DependencyProcessorPlugin implements Plugin<Project> {
         String taskName = "copy${variant.name.capitalize()}Dependencies"
         return project.getTasks().create(taskName, CopyDependenciesTask.class, {
             it.packagesToInclude = extension.packagesToInclude
+            it.packagesToExclude = extension.packagesToExclude
             it.includeInnerDependencies = extension.includeAllInnerDependencies
             it.dependencies = project.configurations.api.getDependencies()
             it.variantName = variant.name
@@ -108,5 +109,6 @@ class DependencyProcessorPlugin implements Plugin<Project> {
     static class PluginExtension {
         boolean includeAllInnerDependencies
         String[] packagesToInclude
+        String[] packagesToExclude
     }
 }

--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
@@ -165,11 +165,11 @@ class CopyDependenciesTask extends DefaultTask {
      * @return
      */
     def processDependency(Dependency dependency, String archiveName, String dependencyPath) {
-		println "files for dep: ${project.fileTree(dependencyPath).getFiles()}"
+        println "files for dep: ${project.fileTree(dependencyPath).getFiles()}"
         project.fileTree(dependencyPath).getFiles().each { file ->
             if (dependency.group in packagesToExclude) {
-				println "dependency in exclusion list"
-			} else if (file.name.endsWith(".pom")) {
+                println "dependency in exclusion list"
+            } else if (file.name.endsWith(".pom")) {
                 println "POM: " + file.name
                 processPomFile(file.path)
             } else {
@@ -177,7 +177,7 @@ class CopyDependenciesTask extends DefaultTask {
                     println "Artifact: " + file.name
                     if (file.name.endsWith(".aar")) {
                         processZipFile(file, dependency.name, dependency.group, dependency.version)
-						println "   |--> zip processed"
+                        println "   |--> zip processed"
                     } else if (file.name.endsWith(".jar")) {
                         if (!file.name.contains("sources")) {
                             copyArtifactFrom(file.path)
@@ -428,16 +428,16 @@ class CopyDependenciesTask extends DefaultTask {
                             println "   /--> " + file.name
                             processPomFile(file.path)
                         } else {
-							println "Artifact: " + file.name
-							if (file.name.endsWith(".aar")) {
-								processZipFile(file, it.artifactId.text(), it.groupId.text(), version)
-							} else if (file.name.endsWith(".jar")) {
-								if (!file.name.contains("sources") && !file.name.contains("javadoc")) {
-									copyArtifactFrom(file.path)
-								} else {
-									println "   |--> Exclude for source and javadoc jar"
-								}
-							}
+                            println "Artifact: " + file.name
+                            if (file.name.endsWith(".aar")) {
+                                processZipFile(file, it.artifactId.text(), it.groupId.text(), version)
+                            } else if (file.name.endsWith(".jar")) {
+                                if (!file.name.contains("sources") && !file.name.contains("javadoc")) {
+                                    copyArtifactFrom(file.path)
+                                } else {
+                                    println "   |--> Exclude for source and javadoc jar"
+                                }
+                            }
                         }
                     }
                 } else {

--- a/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
+++ b/buildSrc/src/main/groovy/com/mobbeel/plugin/task/CopyDependenciesTask.groovy
@@ -17,6 +17,7 @@ class CopyDependenciesTask extends DefaultTask {
     String variantName
     String gradleVersion
     String[] packagesToInclude = [""]
+    String[] packagesToExclude = [""]
 
     @TaskAction
     def executeTask() {
@@ -164,20 +165,24 @@ class CopyDependenciesTask extends DefaultTask {
      * @return
      */
     def processDependency(Dependency dependency, String archiveName, String dependencyPath) {
+		println "files for dep: ${project.fileTree(dependencyPath).getFiles()}"
         project.fileTree(dependencyPath).getFiles().each { file ->
-            if (file.name.endsWith(".pom")) {
+            if (dependency.group in packagesToExclude) {
+				println "dependency in exclusion list"
+			} else if (file.name.endsWith(".pom")) {
                 println "POM: " + file.name
                 processPomFile(file.path)
             } else {
                 if (archiveName == null || file.name == archiveName) {
                     println "Artifact: " + file.name
                     if (file.name.endsWith(".aar")) {
-                        processZipFile(file, dependency)
+                        processZipFile(file, dependency.name, dependency.group, dependency.version)
+						println "   |--> zip processed"
                     } else if (file.name.endsWith(".jar")) {
                         if (!file.name.contains("sources")) {
                             copyArtifactFrom(file.path)
                         } else {
-                            println "   |--> Exclude for source jar"
+                            println "   |--> Exclude for source and javadoc jar"
                         }
                     }
                 }
@@ -186,8 +191,8 @@ class CopyDependenciesTask extends DefaultTask {
         println()
     }
 
-    def processZipFile(File aarFile, Dependency dependency) {
-        String tempDirPath = "${temporaryDir.path}/${dependency.name}_zip"
+    def processZipFile(File aarFile, String dependencyName, String dependencyGroup, String dependencyVersion) {
+        String tempDirPath = "${temporaryDir.path}/${dependencyName}_zip"
 
         project.copy {
             from project.zipTree(aarFile.path)
@@ -201,7 +206,7 @@ class CopyDependenciesTask extends DefaultTask {
             from "${tempFolder.path}"
             include "classes.jar"
             into "${temporaryDir.path}/${variantName}/libs"
-            def jarName = getJarNameFromDependency(dependency)
+            def jarName = getJarNameFromDependency(dependencyName, dependencyGroup, dependencyVersion)
             rename "classes.jar", jarName
         }
 
@@ -236,14 +241,14 @@ class CopyDependenciesTask extends DefaultTask {
         tempFolder.deleteDir()
     }
 
-    def getJarNameFromDependency(Dependency dependency) {
+    def getJarNameFromDependency(String dependencyName, String dependencyGroup, String dependencyVersion) {
         def jarName = ""
-        if (null != dependency.group) {
-            jarName += dependency.group.toLowerCase() + "-"
+        if (null != dependencyGroup) {
+            jarName += dependencyGroup.toLowerCase() + "-"
         }
-        jarName += dependency.name.toLowerCase()
-        if(null != dependency.version && !dependency.version.equalsIgnoreCase('unspecified')) {
-            jarName += "-" + dependency.version
+        jarName += dependencyName.toLowerCase()
+        if(null != dependencyVersion && !dependencyVersion.equalsIgnoreCase('unspecified')) {
+            jarName += "-" + dependencyVersion
         }
         jarName += ".jar"
 
@@ -416,16 +421,23 @@ class CopyDependenciesTask extends DefaultTask {
 
                 println "   |--> Inner dependency: " +  it.groupId.text() + ":" + it.artifactId.text() + ":" + version
 
-                if (includeInnerDependencies || it.groupId.text() in packagesToInclude) {
+                if ((includeInnerDependencies || it.groupId.text() in packagesToInclude) && !(it.groupId.text() in packagesToExclude)) {
                     subJarLocation += it.groupId.text() + "/" + it.artifactId.text() + "/" + version + "/"
                     project.fileTree(subJarLocation).getFiles().each { file ->
                         if (file.name.endsWith(".pom")) {
                             println "   /--> " + file.name
                             processPomFile(file.path)
                         } else {
-                            if (!file.name.contains("sources") && !file.name.contains("javadoc")) {
-                                copyArtifactFrom(file.path)
-                            }
+							println "Artifact: " + file.name
+							if (file.name.endsWith(".aar")) {
+								processZipFile(file, it.artifactId.text(), it.groupId.text(), version)
+							} else if (file.name.endsWith(".jar")) {
+								if (!file.name.contains("sources") && !file.name.contains("javadoc")) {
+									copyArtifactFrom(file.path)
+								} else {
+									println "   |--> Exclude for source and javadoc jar"
+								}
+							}
                         }
                     }
                 } else {


### PR DESCRIPTION
I had some issues with bundling aar dependencies, so made some fixes. The method processZipFile didn't have enough information to get dependencies recursively from the processPomFile, so I added those parameters to the method and made the call.
Also, added a property to exclude packages from bundling, since we had that as our use case at the time.

Took the liberty to bump version to 2.1.1 because we deployed internally, but would be great if you guys published it :)

Thanks